### PR TITLE
Add Go backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,14 @@ _By following these guidelines, you should be able to build a functional and vis
 - Figma design file: [design.fig](./design.fig)
 - Red Hat Text font: https://fonts.google.com/specimen/Red+Hat+Text
 
+
+## Backend Setup
+
+The `backend` folder contains a Go project using Echo and MongoDB. To run it locally:
+
+```bash
+cd backend
+go run ./...
+```
+
+Tests can be executed with `go test ./...`, though fetching dependencies may require network access.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,9 @@
+module github.com/oolio-group/kart-challenge/backend
+
+go 1.21
+
+require (
+github.com/labstack/echo/v4 v4.11.4
+go.mongodb.org/mongo-driver v1.11.0
+)
+

--- a/backend/handlers/handler.go
+++ b/backend/handlers/handler.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+    "net/http"
+
+    "github.com/labstack/echo/v4"
+    "go.mongodb.org/mongo-driver/mongo"
+)
+
+// Handler aggregates dependencies for HTTP handlers.
+type Handler struct {
+    db *mongo.Database
+}
+
+// NewHandler returns a new Handler.
+func NewHandler(db *mongo.Database) *Handler {
+    return &Handler{db: db}
+}
+
+// ListProducts handles GET /product
+func (h *Handler) ListProducts(c echo.Context) error {
+    // TODO: Fetch products from MongoDB
+    return c.JSON(http.StatusOK, []interface{}{})
+}
+
+// GetProduct handles GET /product/:productId
+func (h *Handler) GetProduct(c echo.Context) error {
+    productID := c.Param("productId")
+    _ = productID // TODO: fetch product by ID
+    return c.JSON(http.StatusOK, map[string]interface{}{})
+}
+
+// PlaceOrder handles POST /order
+func (h *Handler) PlaceOrder(c echo.Context) error {
+    // TODO: parse request and store order
+    return c.JSON(http.StatusOK, map[string]interface{}{})
+}

--- a/backend/handlers/handler_test.go
+++ b/backend/handlers/handler_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/labstack/echo/v4"
+)
+
+func TestListProducts(t *testing.T) {
+    e := echo.New()
+    h := &Handler{}
+
+    req := httptest.NewRequest(http.MethodGet, "/product", nil)
+    rec := httptest.NewRecorder()
+    c := e.NewContext(req, rec)
+
+    if err := h.ListProducts(c); err != nil {
+        t.Fatalf("handler returned error: %v", err)
+    }
+    if rec.Code != http.StatusOK {
+        t.Fatalf("expected status 200, got %d", rec.Code)
+    }
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+    "context"
+    "log"
+    "net/http"
+    "time"
+
+    "github.com/labstack/echo/v4"
+    "github.com/labstack/echo/v4/middleware"
+    "go.mongodb.org/mongo-driver/mongo"
+    "go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+    // Create a new Echo instance
+    e := echo.New()
+    e.Use(middleware.Logger())
+    e.Use(middleware.Recover())
+
+    // Connect to MongoDB
+    client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+    if err != nil {
+        log.Fatalf("failed to create mongo client: %v", err)
+    }
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+    defer cancel()
+    if err := client.Connect(ctx); err != nil {
+        log.Fatalf("failed to connect to mongo: %v", err)
+    }
+    defer client.Disconnect(ctx)
+
+    // Initialize handlers with the database client
+    h := NewHandler(client.Database("kart"))
+
+    // Routes
+    e.GET("/product", h.ListProducts)
+    e.GET("/product/:productId", h.GetProduct)
+    e.POST("/order", h.PlaceOrder)
+
+    // Start server
+    if err := e.Start(":8080"); err != nil && err != http.ErrServerClosed {
+        e.Logger.Fatal(err)
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Go backend with Echo and MongoDB
- add placeholder handlers and a simple unit test
- document backend setup in README

## Testing
- `go test ./...` *(fails: missing go.sum entry for modules)*

------
https://chatgpt.com/codex/tasks/task_e_6843c35bf49083299da5359987eaa1e8