### PR TITLE
Add React frontend scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,27 @@ _By following these guidelines, you should be able to build a functional and vis
 - Figma design file: [design.fig](./design.fig)
 - Red Hat Text font: https://fonts.google.com/specimen/Red+Hat+Text
 
+
+## Backend Setup
+
+The `backend` folder contains a Go project using Echo and MongoDB. To run it locally:
+
+```bash
+cd backend
+go run ./...
+```
+
+Tests can be executed with `go test ./...`, though fetching dependencies may require network access.
+
+## Frontend Setup
+
+The `frontend` folder contains a Vite + React project using Mantine.
+To run it locally:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Run unit tests with `npm test` (requires dependencies).

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,9 @@
+module github.com/oolio-group/kart-challenge/backend
+
+go 1.21
+
+require (
+github.com/labstack/echo/v4 v4.11.4
+go.mongodb.org/mongo-driver v1.11.0
+)
+

--- a/backend/handlers/handler.go
+++ b/backend/handlers/handler.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Handler aggregates dependencies for HTTP handlers.
+type Handler struct {
+	db *mongo.Database
+}
+
+// NewHandler returns a new Handler.
+func NewHandler(db *mongo.Database) *Handler {
+	return &Handler{db: db}
+}
+
+// ListProducts handles GET /product
+func (h *Handler) ListProducts(c echo.Context) error {
+	// TODO: Fetch products from MongoDB
+	return c.JSON(http.StatusOK, []interface{}{})
+}
+
+// GetProduct handles GET /product/:productId
+func (h *Handler) GetProduct(c echo.Context) error {
+	productID := c.Param("productId")
+	_ = productID // TODO: fetch product by ID
+	return c.JSON(http.StatusOK, map[string]interface{}{})
+}
+
+// PlaceOrder handles POST /order
+func (h *Handler) PlaceOrder(c echo.Context) error {
+	// TODO: parse request and store order
+	return c.JSON(http.StatusOK, map[string]interface{}{})
+}

--- a/backend/handlers/handler_test.go
+++ b/backend/handlers/handler_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestListProducts(t *testing.T) {
+	e := echo.New()
+	h := &Handler{}
+
+	req := httptest.NewRequest(http.MethodGet, "/product", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.ListProducts(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	// Create a new Echo instance
+	e := echo.New()
+	e.Use(middleware.Logger())
+	e.Use(middleware.Recover())
+
+	// Connect to MongoDB
+	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+	if err != nil {
+		log.Fatalf("failed to create mongo client: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := client.Connect(ctx); err != nil {
+		log.Fatalf("failed to connect to mongo: %v", err)
+	}
+	defer client.Disconnect(ctx)
+
+	// Initialize handlers with the database client
+	h := NewHandler(client.Database("kart"))
+
+	// Routes
+	e.GET("/product", h.ListProducts)
+	e.GET("/product/:productId", h.GetProduct)
+	e.POST("/order", h.PlaceOrder)
+
+	// Start server
+	if err := e.Start(":8080"); err != nil && err != http.ErrServerClosed {
+		e.Logger.Fatal(err)
+	}
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,11 @@
+# Frontend
+
+This folder contains a Vite + React project styled with Mantine.
+
+## Commands
+
+- `npm install` — install dependencies
+- `npm run dev` — start development server on http://localhost:3000
+- `npm run build` — create a production build
+- `npm run preview` — preview the production build
+- `npm test` — run unit tests with Vitest

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Oolio Kart</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@mantine/core": "^6.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@vitejs/plugin-react": "^3.1.0",
+    "typescript": "^5.0.2",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import App from './App';
+
+describe('App', () => {
+  it('renders header', () => {
+    render(<App />);
+    expect(screen.getByText(/Products/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,11 @@
+import { Container, Title } from '@mantine/core';
+import ProductList from './components/ProductList';
+
+export default function App() {
+  return (
+    <Container>
+      <Title order={1}>Products</Title>
+      <ProductList />
+    </Container>
+  );
+}

--- a/frontend/src/components/ProductList.tsx
+++ b/frontend/src/components/ProductList.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { List, Loader } from '@mantine/core';
+
+interface Product {
+  id: string;
+  name: string;
+}
+
+export default function ProductList() {
+  const [products, setProducts] = useState<Product[] | null>(null);
+
+  useEffect(() => {
+    fetch('/product')
+      .then((res) => res.json())
+      .then(setProducts)
+      .catch(() => setProducts([]));
+  }, []);
+
+  if (products === null) {
+    return <Loader />;
+  }
+
+  return (
+    <List>
+      {products.map((p) => (
+        <List.Item key={p.id}>{p.name}</List.Item>
+      ))}
+    </List>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { MantineProvider } from '@mantine/core';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <MantineProvider withGlobalStyles withNormalizeCSS>
+      <App />
+    </MantineProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- add Vite + React + Mantine project skeleton in `frontend`
- include simple product list component and basic test
- document how to run the frontend in the main README
- run gofmt on backend files

## Testing
- `go test ./...` *(fails: missing go.sum entries)*
- `npm test --silent` in `frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c35bf49083299da5359987eaa1e8